### PR TITLE
Ensure stacked warnings do not occur

### DIFF
--- a/src/agent.js
+++ b/src/agent.js
@@ -34,13 +34,13 @@ OctopullAgent.prototype.navigate = function(url) {
 
 OctopullAgent.prototype.request = function(settings) {
 	var self = this;
+
+	if (self._currentRequest !== null) {
+		self._currentRequest.abort();
+		self._currentRequest = null;
+	}
 	
-	self._host.then(function(host) {
-		if (self._currentRequest !== null) {
-			self._currentRequest.abort();
-			self._currentRequest = null;
-		}
-		
+	self._host.then(function(host) {		
 		var url = settings.url;
 		if (!url.startsWith('http')) {
 			url = host + url;

--- a/src/msg-view.js
+++ b/src/msg-view.js
@@ -33,7 +33,7 @@ MessagesView.prototype.addMessage = function(message) {
 }
 
 MessagesView.prototype.clear = function() {
-	
+	this.viewModel.messages([]);
 }
 
 module.exports = MessagesView;

--- a/src/octopull.js
+++ b/src/octopull.js
@@ -26,6 +26,7 @@ view.on("loading", function() {
 
 view.on("load", function(screen) {	
 	if (screen.owner && screen.repository && screen.pull_request && screen.diff_base && screen.diff_head) {
+		view.clear();
 		agent.navigate("repos/" + screen.owner + "/" + screen.repository + "/pulls/" + screen.pull_request + "/diff/" + screen.diff_base + "/" + screen.diff_head);
 	}
 


### PR DESCRIPTION
As mentioned in rmhartog/octopull#12, warnings could stack accidentally when recurring. This pull request ensures the message view is cleared before new messages come in.
