### PR TITLE
Retrieve current repository from different element

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octopull-plugin",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Octopull",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "manifest_version": 2,
   "author": "Reinier Hartog",
   "permissions": [

--- a/src/view.js
+++ b/src/view.js
@@ -107,7 +107,7 @@ OctopullView.prototype.context = function() {
 	var diff_base = null;
 	var diff_head = null;
 	
-	var repo = $(".js-current-repository").first().attr("href");
+	var repo = $(".js-current-repository").first().attr("href") || $("a[data-pjax='#js-repo-pjax-container']").first().attr("href");
 	if (repo) {
 		var match = /^\/([^\/]+)\/([^\/]+)$/.exec(repo);
 		if (match !== null) {


### PR DESCRIPTION
The original element that the `owner/repo` combination was being read from could no longer be identified by the same attributes.
